### PR TITLE
doc: add protoncheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 - [Gmail](https://github.com/vyachkonovalov/polybar-gmail)
 - [ProtonMail](https://github.com/vyachkonovalov/bar-protonmail)
+- [ProtonCheck](https://github.com/servusdei2018/protoncheck)
 - [Crypto](https://github.com/willHol/polybar-crypto)
 - [Bitfinex](https://github.com/BrunnerLivio/bitfinex-polybar)
 - [Spotify](https://github.com/Jvanrhijn/polybar-spotify)


### PR DESCRIPTION
[ProtonCheck](https://github.com/servusdei2018/protoncheck) is an updated ProtonMail module written in Go for waybar/polybar/yabar/i3blocks using ProtonMail's internal API:

```
modules-right = protoncheck

[module/protoncheck]
type = custom/script
exec = ~/bin/protoncheck --username USER@protonmail.com --password PASSWORD
interval = 30
click-left = xdg-open https://mail.protonmail.com/inbox
```